### PR TITLE
A utility that splits a stackstorm subtree pack repo into separate repos

### DIFF
--- a/split-packs.sh
+++ b/split-packs.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -lt 1 ] || [[ $1 =~ "-" ]] ; then
+    echo "Usage: $0 subtree_repo_url [new_org_url]"
+    echo "Example: $0 https://github.com/example/mysubtreerepo.git git@github.com:example2"
+    exit
+fi
+SUBTREE_REPO_URL=$1
+if [ $# -gt 1 ] ; then
+    EXCHANGE_ORG_URL=$2
+else
+    EXCHANGE_ORG_URL=$(dirname $1)
+fi
+if [[ $EXCHANGE_ORG_URL =~ ^http ]]; then
+    EXCHANGE_ORG=$(basename $EXCHANGE_ORG_URL)
+elif [[ $EXCHANGE_ORG_URL =~ ^git ]]; then
+    EXCHANGE_ORG=$(echo $EXCHANGE_ORG_URL | rev | cut -d: -f1 | rev)
+else
+    echo "Invalid git URL: $EXCHANGE_ORG_URL"
+    exit 1
+fi 
+SUBTREE_ORG=$(basename $(dirname $1))
+SUBTREE_REPO=$(basename $1 | cut -d. -f1 )
+EXCHANGE_PREFIX=stackstorm
+
+echo 
+echo "Splitting pack from $SUBTREE_ORG/$SUBTREE_REPO to $EXCHANGE_ORG/$EXCHANGE_PREFIX-pack1, $EXCHANGE_ORG/$EXCHANGE_PREFIX-pack2, etc."
+echo "==========================================================================="
+echo
+
+rm -rf /tmp/$SUBTREE_REPO
+rm -rf /tmp/$EXCHANGE_ORG
+mkdir /tmp/$SUBTREE_REPO /tmp/$EXCHANGE_ORG
+
+git clone $SUBTREE_REPO_URL /tmp/$SUBTREE_REPO
+cd /tmp/$SUBTREE_REPO/packs
+
+echo
+git remote remove origin
+for PACK in `ls`; do
+  echo -n "Moving $PACK... "
+  if ! git ls-remote $EXCHANGE_ORG_URL/$EXCHANGE_PREFIX-$PACK > /dev/null 2>&1
+  then
+  	echo "Remote repo $EXCHANGE_ORG_URL/$EXCHANGE_PREFIX-$PACK not found."
+  	echo
+  	continue
+  fi
+  echo
+  
+  mkdir /tmp/$EXCHANGE_ORG/$PACK
+  cd /tmp/$EXCHANGE_ORG/$PACK
+  cp -R /tmp/$SUBTREE_REPO/. .
+
+  git filter-branch --prune-empty --subdirectory-filter packs/$PACK -f -- master
+  git remote add origin $EXCHANGE_ORG_URL/$EXCHANGE_PREFIX-$PACK.git
+  git fetch --all -q
+
+  if git log -n3 origin/master | grep -q "Transfer from $SUBTREE_ORG/$SUBTREE_REPO."
+  then
+  	echo "Already transferred to $EXCHANGE_ORG_URL/$EXCHANGE_PREFIX-$PACK."
+    echo
+  	continue
+  fi
+  echo
+
+  chmod -R 775 .
+  git commit -q -am "Transfer from $SUBTREE_ORG/$SUBTREE_REPO." > /dev/null
+
+  git push -u origin master --force > /dev/null
+
+  echo "The $PACK pack has been transferred."
+  echo
+done
+echo
+
+rm -rf /tmp/$SUBTREE_REPO
+rm -rf /tmp/$EXCHANGE_ORG
+echo "All done."

--- a/split-packs.sh
+++ b/split-packs.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+##
+#  This migration script is provided without warranty.
+#  Use at your own risk, and backup your repo before running.
+#
+#  Note: This script does not create your remote repo.
+#  It is assumed you have already created an empty repo
+#  on the remote host with the pack name "stackstorm-<pack>".
+##
+
 set -e
 
 if [ $# -lt 1 ] || [[ $1 =~ ^-+h(elp)?$ ]] ; then

--- a/split-packs.sh
+++ b/split-packs.sh
@@ -57,7 +57,7 @@ for PACK in `ls`; do
   git remote add origin $EXCHANGE_ORG_URL/$EXCHANGE_PREFIX-$PACK.git
   git fetch --all -q
 
-  if git log -n3 origin/master | grep -q "Transfer from $SUBTREE_ORG/$SUBTREE_REPO."
+  if git log -n3 --oneline | grep -q "Transfer from $SUBTREE_ORG/$SUBTREE_REPO."
   then
   	echo "Already transferred to $EXCHANGE_ORG_URL/$EXCHANGE_PREFIX-$PACK."
     echo

--- a/split-packs.sh
+++ b/split-packs.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ $# -lt 1 ] || [[ $1 =~ "-" ]] ; then
+if [ $# -lt 1 ] || [[ $1 =~ ^-+h(elp)?$ ]] ; then
     echo "Usage: $0 subtree_repo_url [new_org_url]"
     echo "Example: $0 https://github.com/example/mysubtreerepo.git git@github.com:example2"
     exit


### PR DESCRIPTION
This is a stripped down version of @emedvedev's script:
https://github.com/emedvedev/contrib-transfer/blob/master/transfer.sh

I may have removed too much, but I stripped out the CI and bootstrapping functions.  I wanted this to work with other git hosts, so I removed the github API call that creates an empty remote repo.  

As it currently stands, it is expected that you setup your empty remote repos before running this script.  It warns gracefully if the repo isn't there or has already been migrated.  It follows the new convention for pack project names: `stackstorm-<pack>`.

I don't expect this to merge right away, if there's anything I can do to clean this up please let me know.